### PR TITLE
fix: handle Tupan's main switches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,7 @@ project(net_mikrotik
         DESCRIPTION "Monitoring libraries for network devices")
 find_package(Rock)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 17)
 
 rock_init()
 rock_standard_layout()

--- a/src/RESTAPI.hpp
+++ b/src/RESTAPI.hpp
@@ -1,6 +1,8 @@
 #ifndef NET_MIKROTIK_RESTAPI_HPP
 #define NET_MIKROTIK_RESTAPI_HPP
 
+#include <optional>
+
 #include "InterfaceStats.hpp"
 #include "RESTAPIConfig.hpp"
 #include "restclient-cpp/connection.h"
@@ -97,6 +99,10 @@ namespace net_mikrotik {
         static void throwOnInvalidFieldName(Json::Value const& json,
             std::string const& field_name);
 
+        /** @brief throws an exception that indicatest that the given field does not exist
+         */
+        static void throwFieldNameInvalid(std::string const& field_name);
+
         /**
          * @brief Throws whenever the response code is different from 200. We
          * treat any other code as failure, since all we do is a GET request.
@@ -146,7 +152,8 @@ namespace net_mikrotik {
          * @return uint64_t the parsed value.
          */
         static uint64_t parseUint64Field(Json::Value const& json,
-            std::string const& field_name);
+            std::string const& field_name,
+            std::optional<uint64_t> default_value = std::optional<uint64_t>());
 
         /**
          * @brief Parses a string value read from a json field into bool.


### PR DESCRIPTION
# What is this PR for

The big switches to not have some fields that are present in the smaller routers. Because of this,
we are not gathering statistics about these devices.

This PR makes these fields optional and sets to zero if they are missing.

# Results, How I tested

Connected with the `net_mikrotik_bin` tool on the routers and managed to get the stats.
