### PR TITLE
fix: auto select time format

### DIFF
--- a/src/RESTAPI.cpp
+++ b/src/RESTAPI.cpp
@@ -192,6 +192,18 @@ bool RESTAPI::parseBooleanField(Json::Value const& json, string const& field_nam
     return value == "true";
 }
 
+string RESTAPI::autoSelectTimeFormat(string const& value)
+{
+    auto slash_in_value = value.find("/");
+    if (slash_in_value != string::npos) {
+        // sep/03/2024 16:42:42
+        return "%b/%d/%Y %T";
+    }
+
+    // 2024-09-03 16:42:42
+    return "%Y-%m-%d %T";
+}
+
 Time RESTAPI::parseTimeField(Json::Value const& json, string const& field_name)
 {
     if (!json.isMember(field_name)) {
@@ -199,9 +211,10 @@ Time RESTAPI::parseTimeField(Json::Value const& json, string const& field_name)
     }
 
     string value = json[field_name].asString();
+    auto time_format = autoSelectTimeFormat(value);
     try {
         // Add Z to the time string to treat it as UTC
-        return Time::fromString(value + "Z", Resolution::Seconds, "%b/%d/%Y %T");
+        return Time::fromString(value + "Z", Resolution::Seconds, time_format);
     }
     catch (runtime_error const& err) {
         throw runtime_error(detailedParsingErrorMessage(field_name, value, err.what()));

--- a/src/RESTAPI.hpp
+++ b/src/RESTAPI.hpp
@@ -174,6 +174,18 @@ namespace net_mikrotik {
          */
         static base::Time parseTimeField(Json::Value const& json,
             std::string const& field_name);
+
+        /**
+         * @brief Auto selects the time format based on the data received from the router.
+         *
+         * Currently only supports two formats:
+         *      %b/%d/%Y %T
+         *      %Y-%m-%d %T
+         *
+         * @param value the time data received
+         * @return the time format.
+         */
+        static std::string autoSelectTimeFormat(std::string const& value);
     };
 
 } // end namespace net_mikrotik

--- a/test/rest_responses.json
+++ b/test/rest_responses.json
@@ -37,7 +37,7 @@
         "fp-tx-byte": "13541656",
         "fp-tx-packet": "27226",
         "l2mtu": "1598",
-        "last-link-up-time": "dec/13/2022 09:47:30",
+        "last-link-up-time": "2022-12-13 09:47:30",
         "link-downs": "0",
         "mac-address": "18:FD:74:89:A0:C7",
         "max-l2mtu": "4074",

--- a/test/test_RESTAPI.cpp
+++ b/test/test_RESTAPI.cpp
@@ -248,6 +248,27 @@ TEST_F(RESTAPITest, it_throws_when_there_is_the_value_is_out_of_range)
         out_of_range);
 }
 
+TEST_F(RESTAPITest, it_throws_when_the_time_format_is_not_supported)
+{
+    auto api = RESTAPI();
+
+    auto resource_dir = getenv("NET_MIKROTIK_RESOURCE_DIR");
+    stringstream rest_responses;
+    rest_responses << resource_dir << "rest_responses.json";
+    ifstream file(rest_responses.str(), ifstream::binary);
+
+    Json::FastWriter writer;
+    Json::Value root;
+    file >> root;
+
+    root[0]["last-link-up-time"] = "10/feb/1070 16:42:42";
+
+    RestClient::Response response;
+    response.code = 200;
+    response.body = writer.write(root);
+    ASSERT_THROW({ api.parseInterfaceResponse(response); }, runtime_error);
+}
+
 TEST_F(RESTAPITest, it_doesnt_throw_when_last_link_up_time_field_is_not_present)
 {
     auto api = RESTAPI();


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
Different RouterOS version use different time formats (yay...). I added a very rudimentary way of auto selecting the two that we've seem so far and selecting which one to use.


# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
- [x] Run rubocop and rake tests locally
