### PR TITLE
fix: increase unit test timeout

### DIFF
--- a/src/RESTAPI.cpp
+++ b/src/RESTAPI.cpp
@@ -1,4 +1,5 @@
 #include "RESTAPI.hpp"
+#include <cmath>
 #include <sstream>
 
 using namespace net_mikrotik;
@@ -26,7 +27,7 @@ RestClient::Connection* RESTAPI::setupConnection(std::string const& url,
 {
     auto* connection = new RestClient::Connection(url);
     connection->SetBasicAuth(config.user, config.password);
-    connection->SetTimeout(static_cast<int>(config.timeout.toSeconds()));
+    connection->SetTimeout(std::lround(config.timeout.toSeconds()));
 
     RestClient::HeaderFields headers{};
     headers["content-type"] = "application/json";

--- a/test/test_RESTAPI.cpp
+++ b/test/test_RESTAPI.cpp
@@ -89,7 +89,7 @@ TEST_F(RESTAPITest, it_is_able_to_establish_a_connection_to_google)
     auto api = RESTAPI();
 
     RESTAPIConfig config;
-    config.timeout = base::Time::fromSeconds(1);
+    config.timeout = base::Time::fromSeconds(5);
 
     auto* connection = api.setupConnection("www.google.com", config);
     auto response = connection->get("");


### PR DESCRIPTION
We have a random error with 1s, maybe raising it to 5 will solve the problem.